### PR TITLE
Remove implicit revision of zkllvm-blueprint input of `flake.nix`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -78,17 +78,16 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1712853518,
+        "lastModified": 1713444891,
         "narHash": "sha256-eTnjr51YYlU7PeFH6xJIpytaOne5NFHckLMj3RaxOlI=",
         "ref": "refs/heads/master",
-        "rev": "01964c21ab68e0cd77e08c0a9225f220a5b6bf2d",
+        "rev": "7cf2850fc86fa93ed89d2358fa38f339a51e21b7",
         "revCount": 1204,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/NilFoundation/zkllvm-blueprint"
       },
       "original": {
-        "rev": "01964c21ab68e0cd77e08c0a9225f220a5b6bf2d",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/NilFoundation/zkllvm-blueprint"

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,6 @@
     nil_zkllvm_blueprint = {
       url = "https://github.com/NilFoundation/zkllvm-blueprint";
       type = "git";
-      rev = "01964c21ab68e0cd77e08c0a9225f220a5b6bf2d";
       submodules = true;
     };
     intx = { url = "github:chfast/intx"; flake = false; };


### PR DESCRIPTION
Required fix in blueprint was merged, so there is no need to pin to specific branch here:

- [x] NilFoundation/zkllvm-blueprint/pull/363