### PR TITLE
Update flake inputs for crypto3 and blueprint

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1712603294,
-        "narHash": "sha256-0L7ir0E+jFv9dxmLV6Vxlf+st6BNaJrhRXyNCK3xPsY=",
+        "lastModified": 1715869724,
+        "narHash": "sha256-hiWKxchm26ZZWXwknc3pxgyEvjTahYn3pYkGkZk61bw=",
         "ref": "refs/heads/master",
-        "rev": "13909af052a998c92d2a6a96e0bcfd21156aed72",
-        "revCount": 701,
+        "rev": "f54d95b61bc1b19cd379800011fe8b39845560f7",
+        "revCount": 717,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/NilFoundation/crypto3"
@@ -78,11 +78,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1713444891,
-        "narHash": "sha256-eTnjr51YYlU7PeFH6xJIpytaOne5NFHckLMj3RaxOlI=",
+        "lastModified": 1715930228,
+        "narHash": "sha256-IDY93PPnDg0GTwo/NmPM+uaKpbYcN1RW2pevug8jkC0=",
         "ref": "refs/heads/master",
-        "rev": "7cf2850fc86fa93ed89d2358fa38f339a51e21b7",
-        "revCount": 1204,
+        "rev": "ba5c1638ee5c222c7572cac511073cfc19b0a5ee",
+        "revCount": 1210,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/NilFoundation/zkllvm-blueprint"


### PR DESCRIPTION
Update to latest master Crypto3 and Blueprint.
New essential feature that will become available is `find_package` for `crypto3` and `blueprint`.